### PR TITLE
Fixing Travis infinite loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
         - npm run test
 
     - stage: Version
-      if: tag IS NOT present AND branch = master
+      if: tag IS NOT present AND branch = master AND commit_message !~ /^Version /
       script:
         # Set up SSH key for GitHub
         - >-
@@ -23,10 +23,12 @@ jobs:
         - eval $(ssh-agent -s)
         - ssh-add github_deploy_key
         # Patch for NPM
-        - npm version patch
+        - npm version patch -m "Version %s"
         # Push new tag to GitHub, triggering a new build
         - git remote set-url origin git@github.com:ltonetwork/lto-transactions.git
-        - git push --tags
+        - git push origin HEAD:master --follow-tags
+      on:
+        tags: false
 
     - stage: Release
       if: tag IS present AND branch = master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lto-network/lto-transactions",
-  "version": "1.2.7",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lto-network/lto-transactions",
-  "version": "1.2.7",
+  "version": "1.2.5",
   "description": "Build and sign(multi-sign) transactions for LTO blockchain.",
   "keywords": [
     "lto",


### PR DESCRIPTION
- Fixes an infinite loop on Travis deploy where `Version` would be run forever
  - The `version` job on Travis adds a commit message that matches `/^Version /`, and also does not run when that commit message is matched
- Reverts `package.json` to version `1.2.5`

---