### PR TITLE
Adding transfer schema V1

### DIFF
--- a/src/parseSerialize/schemas.ts
+++ b/src/parseSerialize/schemas.ts
@@ -329,6 +329,21 @@ export const setScriptSchemaV1: TSchema = {
   ],
 }
 
+export const transferSchemaV1: TSchema = {
+  type: 'object',
+  schema: [
+    txFields.type,
+    txFields.version,
+    txFields.type,
+    txFields.senderPublicKey,
+    txFields.timestamp,
+    txFields.amount,
+    txFields.fee,
+    txFields.recipient,
+    txFields.attachment,
+  ],
+}
+
 export const transferSchemaV2: TSchema = {
   type: 'object',
   schema: [
@@ -375,6 +390,7 @@ export const cancelSponsorSchemaV1: TSchema = {
 export const schemasByTypeMap = {
   [TRANSACTION_TYPE.GENESIS]: {},
   [TRANSACTION_TYPE.TRANSFER]: {
+    1: transferSchemaV1,
     2: transferSchemaV2,
   },
   [TRANSACTION_TYPE.LEASE]: {

--- a/src/parseSerialize/schemas.ts
+++ b/src/parseSerialize/schemas.ts
@@ -329,6 +329,9 @@ export const setScriptSchemaV1: TSchema = {
   ],
 }
 
+// This schema is not 100% correct for transfer-v1, it's a workaround for an issue with the Ledger app in the wallet ui
+// Once ledger app is fixed, this will no longer be needed
+// see the issue: https://github.com/iicc1/ledger-app-lto/issues/3
 export const transferSchemaV1: TSchema = {
   type: 'object',
   schema: [


### PR DESCRIPTION
- Adds the schema for `transfer-v1`
  - This is necessary for the ledger-wallet integration, which only works with v1 for now