### PR TITLE
Add support for V3 association and anchor transactions

### DIFF
--- a/src/parseSerialize/schemas.ts
+++ b/src/parseSerialize/schemas.ts
@@ -112,6 +112,11 @@ export namespace txFields {
     fromBytes: byteToAddressOrAlias,
   }]
 
+  export const sponsor: TObjectField = ['sponsor', {
+    toBytes: BASE58_STRING,
+    fromBytes: byteToAddressOrAlias,
+  }]
+
   export const script: TObjectField = ['script', {
     toBytes: SCRIPT,
     fromBytes: byteToScript,
@@ -119,12 +124,17 @@ export namespace txFields {
 
   export const senderPublicKey = base58field32('senderPublicKey')
 
+  // Apparently fixed at 1 in the node code and in python, so lets not support it yet
+  // export const senderKeyType = byteField('senderKeyType')
+
   export const signature: TObjectField = ['signature', {
     toBytes: BASE58_STRING,
     fromBytes: P_BASE58_FIXED(64),
   }]
 
   export const timestamp = longField('timestamp')
+
+  export const expires = longField('expires')
 
   export const type = byteField('type')
 
@@ -181,9 +191,14 @@ export namespace txFields {
     fromBytes: byteToAddressOrAlias,
   }]
 
-  export const hash: TObjectField = ['hash', {
+  export const optHash: TObjectField = ['hash', {
     toBytes: OPTION(LEN(SHORT)(BASE58_STRING)),
     fromBytes: P_OPTION(P_BASE58_VAR(P_SHORT)),
+  }]
+
+  export const hash: TObjectField = ['hash', {
+    toBytes: LEN(SHORT)(BASE58_STRING),
+    fromBytes: P_BASE58_VAR(P_SHORT),
   }]
 
   export const associationType = intField('associationType')
@@ -256,6 +271,22 @@ export const anchorSchemaV1: TSchema = {
   ],
 }
 
+export const anchorSchemaV3: TSchema = {
+  type: 'object',
+  schema: [
+    txFields.type,
+    txFields.version,
+    txFields.chainId,
+    txFields.timestamp,
+    txFields.byteConstant(1),
+    // Not supported in the node and python, so replace by byte constant
+    // txFields.senderKeyType,
+    txFields.senderPublicKey,
+    txFields.fee,
+    txFields.anchors,
+  ],
+}
+
 export const associationSchemaV1: TSchema = {
   type: 'object',
   schema: [
@@ -265,12 +296,30 @@ export const associationSchemaV1: TSchema = {
     txFields.senderPublicKey,
     txFields.party,
     txFields.associationType,
-    txFields.hash,
+    txFields.optHash,
     txFields.timestamp,
     txFields.fee,
   ],
 }
 
+export const associationSchemaV3: TSchema = {
+  type: 'object',
+  schema: [
+    txFields.type,
+    txFields.version,
+    txFields.chainId,
+    txFields.timestamp,
+    // Not supported in the node and python, so replace by byte constant
+    // txFields.senderKeyType,
+    txFields.byteConstant(1),
+    txFields.senderPublicKey,
+    txFields.fee,
+    txFields.recipient,
+    txFields.associationType,
+    txFields.expires,
+    txFields.hash,
+  ],
+}
 export const proofsSchemaV0: TSchema = {
   type: 'object',
   schema: [
@@ -445,9 +494,11 @@ export const schemasByTypeMap = {
   },
   [TRANSACTION_TYPE.ANCHOR]: {
     1: anchorSchemaV1,
+    3: anchorSchemaV3,
   },
   [TRANSACTION_TYPE.INVOKE_ASSOCIATION]: {
     1: associationSchemaV1,
+    3: associationSchemaV3,
   },
   [TRANSACTION_TYPE.REVOKE_ASSOCIATION]: {
     1: associationSchemaV1,

--- a/src/parseSerialize/serialize.ts
+++ b/src/parseSerialize/serialize.ts
@@ -32,8 +32,11 @@ export const serializerFromSchema = <LONG = string | number>(schema: TSchema, fr
     schema.schema.forEach(field => {
       const [name, schema] = field
       let data
-      // Name as array means than we need to serialize many js fields as one binary object. E.g. we need to add length
-      if (Array.isArray(name)){
+      // Added because byteConstant in schema returns noname. Probably should be implemented in a nicer way
+      if (name == 'noname' && 'toBytes' in schema) {
+        data = schema.toBytes()
+      } else if (Array.isArray(name)){
+        // Name as array means than we need to serialize many js fields as one binary object. E.g. we need to add length
         data = name.reduce((acc, fieldName) => ({...acc, [fieldName]: obj[fieldName]}),{} as any)
       }else{
         data = obj[name]

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -29,6 +29,27 @@ export interface WithSender {
   senderPublicKey: string
 }
 
+export interface WithRecipient {
+  /**
+   * Recipient address. This address is the recipient of the transaction
+   */
+  recipient: string
+}
+
+export interface WithOptSponsor {
+  /**
+   * Sponsor account public key. This account will pay fee and this account's script will be executed if exists
+   */
+  sponsorPublicKey?: string
+}
+
+export interface WithExpires {
+  /**
+   * Expiry time. The expiry time of a transaction
+   */
+  expires: number
+}
+
 export interface WithProofs {
   /**
    * ITransaction signatures
@@ -110,6 +131,9 @@ export interface ITransferTransaction<LONG = string | number> extends ITransacti
  */
 export interface IAnchorTransaction<LONG = string | number> extends ITransaction<LONG> {
   type: TRANSACTION_TYPE.ANCHOR
+  chainId?: number
+  // senderKeyType?: number
+  sponsorPublicKey?: string
   anchors: string[]
 }
 
@@ -119,6 +143,13 @@ export interface IAssociationTransaction<LONG = string | number> extends ITransa
   associationType: LONG,
   hash?: string | null,
 }
+
+export interface IAssociationTransactionV3<LONG = string | number> extends ITransaction<LONG>, WithChainId, WithRecipient, WithOptSponsor, WithExpires {
+  sender: string,
+  associationType: LONG,
+  hash?: string | null,
+}
+
 
 /**
  * Used for invoking association transactions.
@@ -203,7 +234,7 @@ export type TTxParams<LONG = string | number> =
   | IMassTransferParams<LONG>
   | ISetScriptParams<LONG>
   | ITransferParams<LONG>
-  | IAssociationParams<LONG>
+  | IAssociationParams<LONG> | IAssociationParamsV3<LONG>
   | ISponsorParams<LONG>
 
 /**
@@ -300,18 +331,30 @@ export interface ITransferParams<LONG = string | number> extends IBasicParams<LO
  * @typeparam LONG Generic type representing LONG type. Default to string | number. Since javascript number more than 2 ** 53 -1 cannot be precisely represented, generic type is used
  */
 export interface IAnchorParams<LONG = string | number> extends IBasicParams<LONG> {
-  anchors: string[]
+  anchors: string[],
 }
 
 /**
  * @typeparam LONG Generic type representing LONG type. Default to string | number. Since javascript number more than 2 ** 53 -1 cannot be precisely represented, generic type is used
  */
 export interface IAssociationParams<LONG = string | number> extends IBasicParams<LONG>, WithChainIdParam {
+  version?: number
   party: string,
   associationType: LONG,
   hash?: string | null,
   sender?: string,
 }
+
+export interface IAssociationParamsV3<LONG = string | number> extends IBasicParams<LONG>, WithChainIdParam {
+  recipient: string,
+  senderKeyType: string,
+  associationType: LONG,
+  expires?: number,
+  hash?: string | null,
+  sender?: string,
+  sponsor?: string,
+}
+
 
 export interface ISponsorParams<LONG = string | number> extends IBasicParams<LONG>, WithChainIdParam {
   recipient: string,

--- a/src/transactions/anchor.ts
+++ b/src/transactions/anchor.ts
@@ -1,19 +1,29 @@
-import { TRANSACTION_TYPE, IAnchorTransaction, IAnchorParams, WithId, WithSender } from '../transactions'
-import { signBytes, hashBytes } from '@lto-network/lto-crypto'
-import {addProof, getSenderPublicKey, convertToPairs, fee } from '../generic'
+import {
+  TRANSACTION_TYPE,
+  IAnchorTransaction,
+  IAnchorParams,
+  WithId,
+  WithSender,
+  WithOptSponsor,
+  WithChainId
+} from '../transactions'
+import {signBytes, hashBytes, chainIdOf} from '@lto-network/lto-crypto'
+import {addProof, getSenderPublicKey, convertToPairs, fee, networkByte} from '../generic'
 import { TSeedTypes } from '../types'
 import { binary } from '../parseSerialize'
 
 /* @echo DOCS */
 export function anchor(params: IAnchorParams, seed: TSeedTypes): IAnchorTransaction & WithId
-export function anchor(paramsOrTx: IAnchorParams & WithSender | IAnchorTransaction, seed?: TSeedTypes): IAnchorTransaction & WithId
+export function anchor(paramsOrTx: IAnchorParams & ( WithSender | WithChainId ) & WithOptSponsor | IAnchorParams & WithSender | IAnchorTransaction, seed?: TSeedTypes): IAnchorTransaction & WithId
 export function anchor(paramsOrTx: any, seed?: TSeedTypes): IAnchorTransaction {
   const type = TRANSACTION_TYPE.ANCHOR
-  const version = paramsOrTx.version || 1
+  const version = paramsOrTx.version || (paramsOrTx.sponsorPublicKey || paramsOrTx.chainId ? 3 : 1)
   const seedsAndIndexes = convertToPairs(seed)
   const senderPublicKey = getSenderPublicKey(seedsAndIndexes, paramsOrTx)
+  const sponsorPublicKey = paramsOrTx.sponsorPublicKey
+  const chainId = paramsOrTx.chainId ? paramsOrTx.chainId : paramsOrTx.sender ? chainIdOf(paramsOrTx.sender).charCodeAt(0) : 76
 
-  const tx: IAnchorTransaction & WithId = {
+  const txToSign: IAnchorTransaction & WithId = {
     type,
     version,
     senderPublicKey,
@@ -23,11 +33,19 @@ export function anchor(paramsOrTx: any, seed?: TSeedTypes): IAnchorTransaction {
     id: '',
     anchors: paramsOrTx.anchors || [],
   }
+  const v3tx : IAnchorTransaction & WithId & WithChainId = {
+    ...txToSign,
+    chainId: networkByte(chainId, 76),
+  }
+  const tx = version == 3 ? v3tx : txToSign
 
   const bytes = binary.serializeTx(tx)
 
   seedsAndIndexes.forEach(([s, i]) => addProof(tx, signBytes(bytes, s), i))
   tx.id = hashBytes(bytes)
+  if (version == 3 && sponsorPublicKey) {
+    tx.sponsorPublicKey = sponsorPublicKey
+  }
 
   return tx
 }

--- a/src/transactions/association.ts
+++ b/src/transactions/association.ts
@@ -3,7 +3,7 @@ import {
   IAssociationTransaction,
   IAssociationParams,
   WithId,
-  WithSender,
+  WithSender, WithProofs, IAssociationParamsV3, IAssociationTransactionV3,
 } from '../transactions'
 import { signBytes, hashBytes, chainIdOf } from '@lto-network/lto-crypto'
 import {addProof, getSenderPublicKey, convertToPairs, fee, networkByte } from '../generic'
@@ -11,23 +11,26 @@ import { TSeedTypes } from '../types'
 import { binary } from '../parseSerialize'
 
 /* @echo DOCS */
-export function invokeAssociation(params: IAssociationParams, seed: TSeedTypes): IAssociationTransaction & WithId
-export function invokeAssociation(paramsOrTx: IAssociationParams & WithSender | IAssociationTransaction, seed?: TSeedTypes): IAssociationTransaction & WithId
-export function invokeAssociation(paramsOrTx: any, seed?: TSeedTypes): IAssociationTransaction {
+export function invokeAssociation(params: IAssociationParams, seed: TSeedTypes): (IAssociationTransaction & WithId) | (IAssociationTransactionV3 & WithId)
+export function invokeAssociation(paramsOrTx: (IAssociationParamsV3 & WithSender) | (IAssociationParams & WithSender) | IAssociationTransaction, seed?: TSeedTypes): (IAssociationTransaction & WithId) | (IAssociationTransactionV3 & WithId)
+export function invokeAssociation(paramsOrTx: any, seed?: TSeedTypes): IAssociationTransaction | IAssociationTransactionV3 {
   const type = TRANSACTION_TYPE.INVOKE_ASSOCIATION
-  const version = paramsOrTx.version || 1
+  const version = paramsOrTx.version || (paramsOrTx.recipient || paramsOrTx.sponsorPublicKey ? 3 : 1)
   const seedsAndIndexes = convertToPairs(seed)
   const senderPublicKey = getSenderPublicKey(seedsAndIndexes, paramsOrTx)
+  // Not used as the backend and python code seems to be fixated on keytype id 1
+  // const senderKeyType = paramsOrTx.senderKeyType || 'ed25519'
   const sender = paramsOrTx.sender
-  const chainId = chainIdOf(paramsOrTx.party).charCodeAt(0)
+  const chainId = chainIdOf(paramsOrTx.party ? paramsOrTx.party : paramsOrTx.recipient).charCodeAt(0)
+  const sponsorPublicKey = paramsOrTx.sponsorPublicKey
 
-  const tx: IAssociationTransaction & WithId = {
+  const v1Tx: IAssociationTransaction & WithId & WithProofs = {
     id: '',
     type,
     version,
     senderPublicKey,
     sender,
-    chainId: networkByte(paramsOrTx.chainId, chainId),
+    chainId,
     fee: fee(paramsOrTx, 100000000),
     timestamp: paramsOrTx.timestamp || Date.now(),
     proofs: paramsOrTx.proofs || [],
@@ -36,10 +39,34 @@ export function invokeAssociation(paramsOrTx: any, seed?: TSeedTypes): IAssociat
     hash: paramsOrTx.hash ? paramsOrTx.hash : '',
   }
 
+  const v3Tx: IAssociationTransactionV3 & WithId & WithProofs = {
+    id: '',
+    type,
+    version,
+    chainId,
+    sender,
+    senderPublicKey,
+    // Not used as the backend and python code seems to be fixated on keytype id 1
+    // senderKeyType,
+    fee: fee(paramsOrTx, 100000000),
+    timestamp: paramsOrTx.timestamp || Date.now(),
+    proofs: paramsOrTx.proofs || [],
+    associationType: paramsOrTx.associationType,
+    hash: paramsOrTx.hash ? paramsOrTx.hash : '',
+    recipient: paramsOrTx.recipient,
+    expires: paramsOrTx.expires || 0,
+    sponsorPublicKey,
+  }
+
+  const tx = version == 3 ? v3Tx : v1Tx
   const bytes = binary.serializeTx(tx)
 
   seedsAndIndexes.forEach(([s, i]) => addProof(tx, signBytes(bytes, s), i))
   tx.id = hashBytes(bytes)
+
+  if (tx === v3Tx && sponsorPublicKey) {
+    tx.sponsorPublicKey = sponsorPublicKey
+  }
 
   return tx
 }

--- a/test/minimalParams.ts
+++ b/test/minimalParams.ts
@@ -9,6 +9,8 @@ import {
   ITransferParams,
   TRANSACTION_TYPE, ISponsorParams, ICancelSponsorParams
 } from '../src/transactions'
+import {IAssociationParamsV3} from '../build/tmp/dist/transactions'
+import {WithChainId} from '../dist/transactions'
 
 export const leaseMinimalParams: ILeaseParams = {
   recipient: '3N3Cn2pYtqzj7N9pviSesNe8KG9Cmb718Y1',
@@ -56,8 +58,24 @@ export const anchorMinimalParams: IAnchorParams = {
   ],
 }
 
+
+export const anchorV3MinimalParams: IAnchorParams & WithChainId = {
+  chainId: 76,
+  anchors: [
+    '7SDYMzGCZVFSwAGs7cFxj2rUBgUB8BVtPnPUuu4itKcX', // someparam
+    '2ZQbGRzfGJEihHoDCdS6DTnvrQV9gkj7KdyapmJ1UbXt', // someparam2
+    '2hy3qKT5PuhWUxe9ACP4HnxRvxzcRqUommTZX4FQp8BE',  // someparam3
+  ],
+}
+
+
 export const associationMinimalParams: IAssociationParams = {
   party: '3N3Cn2pYtqzj7N9pviSesNe8KG9Cmb718Y1',
+  associationType: 0,
+}
+
+export const associationV3MinimalParams: IAssociationParamsV3 = {
+  recipient: '3N3Cn2pYtqzj7N9pviSesNe8KG9Cmb718Y1',
   associationType: 0,
 }
 

--- a/test/transactions/anchor.test.ts
+++ b/test/transactions/anchor.test.ts
@@ -1,9 +1,49 @@
 import { publicKey, verifySignature } from '@lto-network/lto-crypto'
 import { anchor } from '../../src'
-import { anchorMinimalParams } from '../minimalParams'
+import {anchorMinimalParams, anchorV3MinimalParams} from '../minimalParams'
 import { binary } from '../../src/parseSerialize'
 
-describe('anchor', () => {
+describe('anchor v3', () => {
+
+  const stringSeed = 'df3dd6d884714288a39af0bd973a1771c9f00f168cf040d6abb6a50dd5e055d8'
+
+  it('should build from minimal set of params', () => {
+    const tx = anchor({ ...anchorV3MinimalParams } as any, stringSeed)
+    expect(tx.anchors.length).toEqual(3)
+    expect(tx.proofs.length).toEqual(1)
+  })
+
+  it('Should get correct signature', () => {
+    const tx = anchor({ ...anchorV3MinimalParams }, stringSeed)
+    expect(verifySignature(publicKey(stringSeed), binary.serializeTx(tx), tx.proofs[0]!)).toBeTruthy()
+  })
+
+  it('Should get correct multiSignature', () => {
+    const stringSeed2 = 'example seed 2'
+    const tx = anchor({ ...anchorV3MinimalParams }, [null, stringSeed, null, stringSeed2])
+    expect(verifySignature(publicKey(stringSeed), binary.serializeTx(tx), tx.proofs[1]!)).toBeTruthy()
+    expect(verifySignature(publicKey(stringSeed2), binary.serializeTx(tx), tx.proofs[3]!)).toBeTruthy()
+  })
+
+  // Test correct serialization.Compare with value from old anchor function version
+  it('Should correctly serialize', () => {
+    const anchorParams = {
+      anchors: [
+        '7SDYMzGCZVFSwAGs7cFxj2rUBgUB8BVtPnPUuu4itKcX', // someparam
+        '2ZQbGRzfGJEihHoDCdS6DTnvrQV9gkj7KdyapmJ1UbXt', // someparam2
+        '2hy3qKT5PuhWUxe9ACP4HnxRvxzcRqUommTZX4FQp8BE',  // someparam3
+      ],
+      timestamp: 100000,
+      chainId: 76,
+    }
+    const tx = anchor(anchorParams, 'seed')
+    const barr = '15,3,76,0,0,0,0,0,1,134,160,1,26,205,53,236,36,225,249,197,208,91,167,95,7,134,151,79,89,254,109,158,209,102,127,50,190,240,113,147,22,40,192,217,0,0,0,0,2,22,14,192,0,3,0,32,95,155,210,85,244,27,229,109,59,226,20,147,164,173,233,209,26,164,28,79,64,222,152,12,27,157,116,106,245,216,244,252,0,32,23,40,242,111,105,242,9,209,49,85,32,185,52,151,180,184,122,95,115,170,185,81,232,46,13,188,109,4,234,144,201,31,0,32,25,90,75,62,114,125,73,18,148,213,11,160,29,102,250,187,83,239,83,246,236,94,13,21,71,20,218,91,59,52,136,149'
+    expect(binary.serializeTx(tx).toString()).toEqual(barr)
+  })
+})
+
+
+describe('anchor v1', () => {
 
   const stringSeed = 'df3dd6d884714288a39af0bd973a1771c9f00f168cf040d6abb6a50dd5e055d8'
 

--- a/test/transactions/invoke-association.test.ts
+++ b/test/transactions/invoke-association.test.ts
@@ -1,9 +1,60 @@
 import { publicKey, verifySignature } from '@lto-network/lto-crypto'
 import { invokeAssociation } from '../../src'
-import { associationMinimalParams } from '../minimalParams'
+import {associationMinimalParams, associationV3MinimalParams} from '../minimalParams'
 import { binary } from '../../src/parseSerialize'
+import {IAssociationParamsV3} from '../../src/transactions'
 
-describe('invokeAssociation', () => {
+describe('invokeAssociation v3', () => {
+
+  const stringSeed = 'df3dd6d884714288a39af0bd973a1771c9f00f168cf040d6abb6a50dd5e055d8'
+
+  it('should build from minimal set of params', () => {
+    const tx = invokeAssociation({ ...associationV3MinimalParams } as any, stringSeed)
+    expect(tx).toMatchObject({ ...associationV3MinimalParams })
+    expect(tx.proofs.length).toEqual(1)
+  })
+
+  it('Should get correct signature', () => {
+    const tx = invokeAssociation({ ...associationV3MinimalParams }, stringSeed)
+    expect(verifySignature(publicKey(stringSeed), binary.serializeTx(tx), tx.proofs[0]!)).toBeTruthy()
+  })
+
+  it('Should get correct multiSignature', () => {
+    const stringSeed2 = 'example seed 2'
+    const tx = invokeAssociation({ ...associationV3MinimalParams }, [null, stringSeed, null, stringSeed2])
+    expect(verifySignature(publicKey(stringSeed), binary.serializeTx(tx), tx.proofs[1]!)).toBeTruthy()
+    expect(verifySignature(publicKey(stringSeed2), binary.serializeTx(tx), tx.proofs[3]!)).toBeTruthy()
+  })
+
+  it('Should correctly serialize with some params', () => {
+    const params = {
+      hash: '7SDYMzGCZVFSwAGs7cFxj2rUBgUB8BVtPnPUuu4itKcX', // someparam
+      associationType: 10,
+      recipient: '3N3Cn2pYtqzj7N9pviSesNe8KG9Cmb718Y1',
+      timestamp: 100000,
+    }
+    const tx = invokeAssociation(params, 'seed')
+    const barr = '16,3,84,0,0,0,0,0,1,134,160,1,26,205,53,236,36,225,249,197,208,91,167,95,7,134,151,79,89,254,109,158,209,102,127,50,190,240,113,147,22,40,192,217,0,0,0,0,5,245,225,0,1,84,145,193,229,53,69,107,116,171,107,232,58,228,4,39,243,26,134,114,65,147,175,90,181,34,0,0,0,10,0,0,0,0,0,0,0,0,0,32,95,155,210,85,244,27,229,109,59,226,20,147,164,173,233,209,26,164,28,79,64,222,152,12,27,157,116,106,245,216,244,252'
+    expect(binary.serializeTx(tx).toString()).toEqual(barr)
+  })
+
+  it('Should correctly serialize with all params', () => {
+    const params : IAssociationParamsV3 = {
+      hash: '7SDYMzGCZVFSwAGs7cFxj2rUBgUB8BVtPnPUuu4itKcX',
+      associationType: 272,
+      recipient: '3N3Cn2pYtqzj7N9pviSesNe8KG9Cmb718Y1',
+      timestamp: 100000,
+      fee: 100000001,
+      expires: 20234,
+    }
+    const tx = invokeAssociation(params, 'seed')
+    const barr = '16,3,84,0,0,0,0,0,1,134,160,1,26,205,53,236,36,225,249,197,208,91,167,95,7,134,151,79,89,254,109,158,209,102,127,50,190,240,113,147,22,40,192,217,0,0,0,0,5,245,225,1,1,84,145,193,229,53,69,107,116,171,107,232,58,228,4,39,243,26,134,114,65,147,175,90,181,34,0,0,1,16,0,0,0,0,0,0,79,10,0,32,95,155,210,85,244,27,229,109,59,226,20,147,164,173,233,209,26,164,28,79,64,222,152,12,27,157,116,106,245,216,244,252'
+    expect(binary.serializeTx(tx).toString()).toEqual(barr)
+  })
+})
+
+
+describe('invokeAssociation v1', () => {
 
   const stringSeed = 'df3dd6d884714288a39af0bd973a1771c9f00f168cf040d6abb6a50dd5e055d8'
 


### PR DESCRIPTION
This PR adds support for V3 association and anchor transactions.

Obviously I haven't developed with the lib before, so some choices might have to be implemented differently.

I did add a workaround in the serializer for constant byte fields, which to me look like it could have never worked for other transactions that have a constant byte in them (at least not when sent across the wire)